### PR TITLE
[🐛] fix syntax when several branches are visible

### DIFF
--- a/Sublundo.sublime-syntax
+++ b/Sublundo.sublime-syntax
@@ -6,13 +6,16 @@ hidden: true
 scope: text.sublundo.tree
 contexts:
   main:
-    - match: '(o)  (\d+) (.+)$'
+    - match: '\||/'
+      scope: punctuation.tree.branch.sublundo
+    - match: \bo\b
+      scope: punctuation.tree.node.sublundo
+    - match: '  (\d+) (.+)$'
       captures:
-        1: meta.sublundo.tree.node
-        2: constant.other.sublundo.tree.index
-        3: comment.sublundo.tree.label
-    - match: '(@)  (\[\d+\]) (.+)$'
+        1: constant.numeric.tree.index.sublundo
+        2: comment.tree.label.sublundo
+    - match: '(@)  (\[?\d+\]) (.+)$'
       captures:
-        1: keyword.other.sublundo.tree.position
-        2: constant.other.sublundo.tree.index
-        3: comment.sublundo.tree.label
+        1: keyword.other.tree.position.sublundo
+        2: constant.numeric.tree.index.sublundo
+        3: comment.tree.label.sublundo

--- a/test/syntax_test.txt
+++ b/test/syntax_test.txt
@@ -1,9 +1,23 @@
 # SYNTAX TEST "Packages/Sublundo/Sublundo.sublime-syntax"
 
-o  [2] 11 hours ago
-#      ^ comment.sublundo.tree.label
+o  5 11 hours ago
+#    ^ comment.tree.label.sublundo
 |
-o  [1] Root
-#   ^ constant.other.sublundo.tree.index
-#      ^ comment.sublundo.tree.label
+| o  4 5 seconds ago
+# <- punctuation.tree.branch.sublundo
+# ^ punctuation.tree.node.sublundo
+#    ^ constant.numeric.tree.index.sublundo
+#      ^ comment.tree.label.sublundo
+| |
+o |  3 29 seconds ago
+# <- punctuation.tree.node.sublundo
+# ^ punctuation.tree.branch.sublundo
+#    ^ constant.numeric.tree.index.sublundo
+#      ^ comment.tree.label.sublundo
+|/
+o  2 33 seconds ago
+|
+@  [1] Root
+#   ^ constant.numeric.tree.index.sublundo
+#      ^ comment.tree.label.sublundo
 


### PR DESCRIPTION
fix #1 

I also propose to rename scopes to follow [ST guidelines](https://www.sublimetext.com/docs/3/scope_naming.html)

- When writing a syntax, unless otherwise noted, the syntax name should be the final segment of a dotted name. 
- Meta scopes are used to scope larger sections of code or markup, generally containing multiple, more specific scopes.

It's not a big deal but better start with the right thing !